### PR TITLE
Fix tmux config colours

### DIFF
--- a/aliases
+++ b/aliases
@@ -9,5 +9,3 @@ alias la='ls -A'
 alias l='ls -1'
 
 alias t='tree'
-
-alias tmux='TERM=xterm-256color tmux'

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -3,8 +3,8 @@
 # ==========================
 
 # Handle tmux colors
-set -g default-terminal "screen-256color"
-set-option -ga terminal-overrides ",xterm*:RGB"
+set -g default-terminal "${TERM}"
+set -ga terminal-overrides ",xterm-256color:Tc,alacritty:RGB"
 
 # Regarding timing for different events
 set-option -g repeat-time 350


### PR DESCRIPTION
remove alias for term environment variable and instead fix the tmux.config